### PR TITLE
Support readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ By clicking http://localhost:8080/swagger-ui/
 
 ### 5. Open another terminal, upload a file, download it, and list a directory.
 ```
-$ echo "test $(date)" | curl -X PUT -d @- http://localhost:8080/api/content/myfiles/foo/bar.txt
-$ curl http://localhost:8080/api/content/myfiles/foo/bar.txt
-$ curl http://localhost:8080/api/browse/myfiles/foo
+$ echo "test $(date)" | curl -X PUT -d @- http://localhost:8080/api/storage/content/myfiles/foo/bar.txt
+$ curl http://localhost:8080/api/storage/content/myfiles/foo/bar.txt
+$ curl http://localhost:8080/api/storage/browse/myfiles/foo
 ```
 
 ## Scale up

--- a/src/main/java/org/commonjava/service/storage/config/StorageServiceConfig.java
+++ b/src/main/java/org/commonjava/service/storage/config/StorageServiceConfig.java
@@ -29,4 +29,7 @@ public interface StorageServiceConfig
 {
     @WithName( "baseDir" )
     File baseDir();
+
+    @WithName( "readonly" )
+    boolean readonly();
 }

--- a/src/main/java/org/commonjava/service/storage/filter/ReadonlyFilter.java
+++ b/src/main/java/org/commonjava/service/storage/filter/ReadonlyFilter.java
@@ -1,0 +1,38 @@
+package org.commonjava.service.storage.filter;
+
+import io.vertx.core.http.HttpServerRequest;
+import org.commonjava.service.storage.config.StorageServiceConfig;
+
+import javax.enterprise.inject.spi.CDI;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class ReadonlyFilter implements ContainerRequestFilter
+{
+    @Context
+    UriInfo info;
+
+    @Context
+    HttpServerRequest request;
+
+    @Override
+    public void filter( ContainerRequestContext context )
+    {
+        // filter is not a bean, so we can not Inject config but get it via CDI api.
+        StorageServiceConfig serviceConfig = CDI.current().select(StorageServiceConfig.class).get();
+        if ( serviceConfig.readonly() )
+        {
+            // only allow GET methods
+            if ( !context.getMethod().equals(HttpMethod.GET) )
+            {
+                context.abortWith( Response.status(Response.Status.METHOD_NOT_ALLOWED).build() );
+            }
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,12 +44,12 @@ cassandra:
     keyspace: indystorage
 
 storage:
-    baseDir: "/opt/indy/var/lib/indy/storage/storage"
+    baseDir: "/tmp"
+    readonly: false
 
 #kafka:
 #    bootstrap:
 #        servers: "localhost:9092"
-
 
 "%dev":
     quarkus:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -39,6 +39,7 @@ cassandra:
 
 storage:
     baseDir: "/tmp"
+    readonly: false
 
 #kafka:
 #    bootstrap:


### PR DESCRIPTION
I add the ReadonlyFilter but it is not a cdi bean. I have to use cdi api to get the config obj. Let me know if any better way to do the filter on Quarkus.