### PR TITLE
Use path style for cleanup results

### DIFF
--- a/src/main/java/org/commonjava/service/storage/controller/StorageController.java
+++ b/src/main/java/org/commonjava/service/storage/controller/StorageController.java
@@ -16,6 +16,7 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -153,13 +154,14 @@ public class StorageController
         for ( String fs : filesystems )
         {
             for (String path : paths) {
+                String mergedPath = Paths.get(fs, path).toString();
                 if ( fileManager.delete( fs, path ) )
                 {
-                    success.add( fs + ":" + path );
+                    success.add( mergedPath );
                 }
                 else
                 {
-                    failures.add( fs + ":" + path );
+                    failures.add( mergedPath );
                 }
             }
         }

--- a/src/test/java/org/commonjava/service/storage/StorageControllerTest.java
+++ b/src/test/java/org/commonjava/service/storage/StorageControllerTest.java
@@ -7,6 +7,7 @@ import org.commonjava.service.storage.dto.FileInfoObj;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -56,7 +57,8 @@ public class StorageControllerTest extends StorageTest
         HashSet<String> paths = new HashSet<>();
         paths.add(PATH);
         BatchCleanupResult cleanupResult = controller.cleanup( paths, repos );
-        assertEquals( filesystem + ":" + PATH, String.join( ",", cleanupResult.getSucceeded() ) );
+        String expected = Paths.get(filesystem, PATH).toString();
+        assertEquals( expected, String.join( ",", cleanupResult.getSucceeded() ) );
 
         // After cleanup
         result = controller.getFileInfo( filesystem, PATH );
@@ -64,4 +66,3 @@ public class StorageControllerTest extends StorageTest
     }
 
 }
-

--- a/src/test/java/org/commonjava/service/storage/StorageResourceTest.java
+++ b/src/test/java/org/commonjava/service/storage/StorageResourceTest.java
@@ -198,7 +198,7 @@ public class StorageResourceTest
         JsonArray request = new JsonArray();
         request.add( "maven:remote:central" );
         request.add( "maven:group:public" );
-        System.out.println(">>>" + request);
+        //System.out.println(">>>" + request);
         Response response = given().contentType( ContentType.JSON )
                                    .body( request.toString() )
                                    .pathParam( "path", PATH)


### PR DESCRIPTION
Previously I used a colon to separate the filesystem and path. It is not good because colon is also used in filesystem names. This pr uses general path's style to return the cleanup results.