### PR TITLE
Add maint api to purge empty filesystems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <path-mapped-storage.version>2.2</path-mapped-storage.version>
+        <path-mapped-storage.version>2.3-SNAPSHOT</path-mapped-storage.version>
         <toolchains-plugin.version>3.0.0</toolchains-plugin.version>
         <cassandra-maven-plugin.version>3.6</cassandra-maven-plugin.version>
         <cassandra-unit.version>3.7.1.0</cassandra-unit.version>

--- a/src/main/java/org/commonjava/service/storage/controller/StorageController.java
+++ b/src/main/java/org/commonjava/service/storage/controller/StorageController.java
@@ -201,6 +201,19 @@ public class StorageController
         return emptyList();
     }
 
+    public Collection<? extends Filesystem> getEmptyFilesystems()
+    {
+        return fileManager.getFilesystems().stream()
+                .filter(filesystem -> filesystem.getFileCount() == 0)
+                .collect(Collectors.toList());
+    }
+
+    public void purgeEmptyFilesystems()
+    {
+        Collection<? extends Filesystem> ret = getEmptyFilesystems();
+        ret.forEach( filesystem -> fileManager.purgeFilesystem( filesystem ));
+    }
+
     /**
      * By default, the pathmap storage will override existing paths. Here we must check:
      * 1. all paths exist in source

--- a/src/main/java/org/commonjava/service/storage/jaxrs/StorageMaintResource.java
+++ b/src/main/java/org/commonjava/service/storage/jaxrs/StorageMaintResource.java
@@ -1,0 +1,55 @@
+package org.commonjava.service.storage.jaxrs;
+
+import org.commonjava.service.storage.controller.StorageController;
+import org.commonjava.storage.pathmapped.model.Filesystem;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import java.util.Collection;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Tag( name = "Storage maintenance api", description = "Resource for storage" )
+@ApplicationScoped
+@Path( StorageMaintResource.API_MAINT_BASE)
+public class StorageMaintResource
+{
+    public final static String API_MAINT_BASE = "/api/storage/maint";
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    StorageController controller;
+
+    @Operation( summary = "Get empty filesystems." )
+    @APIResponses( { @APIResponse( responseCode = "200", description = "The empty filesystems." ) } )
+    @Produces( APPLICATION_JSON )
+    @GET
+    @Path( "filesystems/empty" )
+    public Response getEmptyFilesystems()
+    {
+        logger.info( "Get empty filesystems" );
+        Collection<? extends Filesystem> result = controller.getEmptyFilesystems();
+        logger.debug( "Get empty filesystems, result: {}", result );
+        return Response.ok( result ).build();
+    }
+
+    @Operation( summary = "Purge empty filesystems." )
+    @APIResponses( { @APIResponse( responseCode = "200", description = "Purge done." ) } )
+    @DELETE
+    @Path( "filesystems/empty" )
+    public Response purgeEmptyFilesystems()
+    {
+        logger.info( "Purge empty filesystems" );
+        controller.purgeEmptyFilesystems();
+        return Response.ok().build();
+    }
+}


### PR DESCRIPTION
This clean up operation is not a common task. The best fit is to make it as a maintenance API in storage service, and call it manually when needed. 
It contains two REST api with same path "maint/filesystems/empty". When use GET, it returns the empty filesystems. With DELETE, it removes them. Users should call the GET to take a look, then call DELETE if necessary.