### PR TITLE
Fix NPE when batch cleanup request contains null paths

### DIFF
--- a/src/main/java/org/commonjava/service/storage/controller/StorageController.java
+++ b/src/main/java/org/commonjava/service/storage/controller/StorageController.java
@@ -187,18 +187,22 @@ public class StorageController
         return result;
     }
 
-    public BatchDeleteResult cleanup(Set<String> paths, String filesystem) {
+    public BatchDeleteResult cleanup(Set<String> paths, String filesystem)
+    {
         Set<String> succeeded = new HashSet<>();
         Set<String> failed = new HashSet<>();
-        for ( String p : paths )
+        if ( paths != null )
         {
-            if ( fileManager.delete( filesystem, p ) )
+            for (String p : paths)
             {
-                succeeded.add( p );
-            }
-            else
-            {
-                failed.add( p );
+                if (fileManager.delete(filesystem, p))
+                {
+                    succeeded.add(p);
+                }
+                else
+                {
+                    failed.add(p);
+                }
             }
         }
         BatchDeleteResult result = new BatchDeleteResult();

--- a/src/main/java/org/commonjava/service/storage/jaxrs/StorageResource.java
+++ b/src/main/java/org/commonjava/service/storage/jaxrs/StorageResource.java
@@ -227,10 +227,11 @@ public class StorageResource
     public Response copy( final FileCopyRequest request )
     {
         final int size = request.getPaths() != null ? request.getPaths().size() : -1;
-        logger.info( "Copying (size: {}): {}", size, request );
+        logger.info( "File copy (size: {}): {}", size, request );
         FileCopyResult result = controller.copy( request );
 
-        logger.debug( "File copy result: {}", result );
+        logger.debug( "File copy result (source: {}, target: {}): {}", request.getSourceFilesystem(),
+                request.getTargetFilesystem(), result );
         return responseHelper.formatOkResponseWithJsonEntity( result );
     }
 


### PR DESCRIPTION
This is for ticket MMENG-3696 "Promotion fails on Indy (via repository driver)"
Fix NPE when batch deletion has null paths. 
`Caused by: java.lang.NullPointerException
	at org.commonjava.service.storage.controller.StorageController.cleanup(StorageController.java:193)
	at org.commonjava.service.storage.controller.StorageController_ClientProxy.cleanup(Unknown Source)
	at org.commonjava.service.storage.jaxrs.StorageResource.cleanup(StorageResource.java:294)`

This could cause promotion service to fail on 500 error, which hides the real promotion error messages.
