### PR TITLE
Set creation and expiration for copied entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <path-mapped-storage.version>2.4</path-mapped-storage.version>
+        <path-mapped-storage.version>2.5-SNAPSHOT</path-mapped-storage.version>
         <toolchains-plugin.version>3.0.0</toolchains-plugin.version>
         <cassandra-maven-plugin.version>3.6</cassandra-maven-plugin.version>
         <cassandra-unit.version>3.7.1.0</cassandra-unit.version>

--- a/src/main/java/org/commonjava/service/storage/controller/StorageController.java
+++ b/src/main/java/org/commonjava/service/storage/controller/StorageController.java
@@ -288,6 +288,19 @@ public class StorageController
                 request.getTargetFilesystem() );
 
         final AtomicInteger copied = new AtomicInteger();
+
+        // Update creation (current time) and expiration for copied file
+        final Date current = new Date();
+        final Date expiration;
+        if ( request.getTimeoutSeconds() > 0 )
+        {
+            expiration = new Date( current.getTime() + TimeUnit.SECONDS.toMillis(request.getTimeoutSeconds()) );
+        }
+        else
+        {
+            expiration = null; // never expire
+        }
+
         request.getPaths().forEach( p -> {
             if ( existing.contains( p ) )
             {
@@ -295,7 +308,7 @@ public class StorageController
             }
             else
             {
-                fileManager.copy(request.getSourceFilesystem(), p, request.getTargetFilesystem(), p);
+                fileManager.copy(request.getSourceFilesystem(), p, request.getTargetFilesystem(), p, current, expiration);
                 completed.add(p);
                 logger.debug( "Copied ({}) {}", copied.incrementAndGet(), p );
             }

--- a/src/main/java/org/commonjava/service/storage/dto/FileCopyRequest.java
+++ b/src/main/java/org/commonjava/service/storage/dto/FileCopyRequest.java
@@ -15,20 +15,19 @@
  */
 package org.commonjava.service.storage.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import java.util.Set;
 
 public class FileCopyRequest
 {
     private Set<String> paths;
 
-    @JsonIgnore
     private boolean failWhenExists;
 
     private String sourceFilesystem;
 
     private String targetFilesystem;
+
+    private int timeoutSeconds;
 
     public Set<String> getPaths() {
         return paths;
@@ -62,6 +61,14 @@ public class FileCopyRequest
         this.targetFilesystem = targetFilesystem;
     }
 
+    public int getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    public void setTimeoutSeconds(int timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
     @Override
     public String toString() {
         return "FileCopyRequest{" +
@@ -69,6 +76,7 @@ public class FileCopyRequest
                 ", failWhenExists=" + failWhenExists +
                 ", sourceFilesystem='" + sourceFilesystem + '\'' +
                 ", targetFilesystem='" + targetFilesystem + '\'' +
+                ", timeoutSeconds=" + timeoutSeconds +
                 '}';
     }
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -15,6 +15,8 @@ quarkus:
         category:
             "org.commonjava.service.storage":
                 level: DEBUG
+            "org.commonjava.storage.pathmapped":
+                level: DEBUG
         console:
             level: DEBUG
             enable: true


### PR DESCRIPTION
Add 'timeoutSeconds' to copy request to set creation and expiration for copied entry properly. The promotion service will send the timeout based on target repository config.