### PR TITLE
Add api to purge specified filesystem

### DIFF
--- a/src/main/java/org/commonjava/service/storage/config/StorageServiceConfig.java
+++ b/src/main/java/org/commonjava/service/storage/config/StorageServiceConfig.java
@@ -32,4 +32,7 @@ public interface StorageServiceConfig
 
     @WithName( "readonly" )
     boolean readonly();
+
+    @WithName( "removableFilesystemPattern" )
+    String removableFilesystemPattern();
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -42,3 +42,4 @@ cassandra:
 storage:
     baseDir: "/tmp"
     readonly: false
+    removableFilesystemPattern: ".+:(remote|group):.+"


### PR DESCRIPTION
This is for [MMENG-3964](https://issues.redhat.com/browse/MMENG-3964) - Support "deleteContent" param with repositoy deletion in repo service.
Add REST api "/api/storage/maint/filesystem/{filesystem}" to purge specified filesystem. For safe, I also add a config 'removableFilesystemPattern' to only allow to remove "remote/group" type of file system.

This api will be called by either content service or repo service.