### PR TITLE
Add default value for removableFilesystemPattern

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -66,6 +66,7 @@ cassandra:
 storage:
     baseDir: "/tmp"
     readonly: false
+    removableFilesystemPattern: ".+:(remote|group):.+"
 
 "%dev":
     quarkus:


### PR DESCRIPTION
The default value was added to test resource but missed in normal application.yaml. This pr amends it.