### PR TITLE
Update to 2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.commonjava.indy.service</groupId>
     <artifactId>pathmap-storage-service</artifactId>
-    <version>1.5-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
 
     <name>Indy :: Service :: PathMap Storage</name>
     <inceptionYear>2021</inceptionYear>
@@ -42,7 +42,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <path-mapped-storage.version>2.7-SNAPSHOT</path-mapped-storage.version>
+        <path-mapped-storage.version>2.8</path-mapped-storage.version>
         <toolchains-plugin.version>3.0.0</toolchains-plugin.version>
         <cassandra-maven-plugin.version>3.8</cassandra-maven-plugin.version>
         <quarkus.package.type>uber-jar</quarkus.package.type>


### PR DESCRIPTION
As always, jump to 2.0 for jakarta namespace.